### PR TITLE
Remove mm-common module

### DIFF
--- a/org.svxlink.Qtel.yaml
+++ b/org.svxlink.Qtel.yaml
@@ -51,6 +51,8 @@ modules:
       no-debuginfo: true
     cleanup:
       - /bin
+    post-install:
+      - chmod u+w ${FLATPAK_DEST}/lib/libtcl*.so*
     sources:
       - type: archive
         url: https://downloads.sourceforge.net/project/tcl/Tcl/8.6.13/tcl8.6.13-src.tar.gz

--- a/org.svxlink.Qtel.yaml
+++ b/org.svxlink.Qtel.yaml
@@ -24,16 +24,8 @@ cleanup:
   - "*.la"
 
 modules:
-  - name: mm-common
-    cleanup:
-      - /bin
-      - /lib
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.6.tar.xz
-        sha256: b55c46037dbcdabc5cee3b389ea11cc3910adb68ebe883e9477847aa660862e7
-
   - name: libsigc++-2.0
+    buildsystem: meson
     sources:
       - type: archive
         url: https://github.com/libsigcplusplus/libsigcplusplus/releases/download/2.12.1/libsigc++-2.12.1.tar.xz


### PR DESCRIPTION
When building libxml++, libsigc++ and glibmm from current release tarballs,
mm-common is no longer needed. See:
- libxml++ [NEWS](https://github.com/libxmlplusplus/libxmlplusplus/blob/e37ba77403cbbdccf1975043bd05df881c4ed024/NEWS#L187):
> Do not require mm-common during the tarball build.

- libsig++ [NEWS](https://github.com/libsigcplusplus/libsigcplusplus/blob/5cdc3cfba613ced119e2853bce85a070dbcca46a/NEWS#L712):
> New build system based on mm-common. The mm-common module is now
> required for building from the git repository, but not for builds
> of release archives.

- glibmm [NEWS](https://github.com/GNOME/glibmm/blob/efa83dfd2e1fb413eb8da9af870f1ffd8a632399/NEWS#L3741):
> Remove the dependency on mm-common during the tarball build.

Thanks to @yakushabb for bringing this to my attention in https://github.com/flathub/org.kde.kmymoney/pull/78

Source: https://github.com/flathub/org.kde.kmymoney/pull/80